### PR TITLE
Implement Rust-style `Result` type

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
 	extends: "eslint-config-infernal",
 	parserOptions: {
 		tsconfigRootDir: __dirname,
-		project: ["./packages/*/tsconfig.json", "apps/*/tsconfig.json"],
+		project: ["./packages/*/tsconfig*.json", "apps/*/tsconfig.json"],
 	},
 	root: true,
 	ignorePatterns: ["next-env.d.ts"],

--- a/packages/result/README.md
+++ b/packages/result/README.md
@@ -1,0 +1,46 @@
+# @furinkapp/result
+
+Fancy error handling for your functions, sync and async alike!
+
+## Usage
+
+```ts
+import { Result, ok, err } from "@furinkapp/result";
+
+function divide(a: number, b: number): Result<number, string> {
+	if (b === 0) {
+		return err("Cannot divide by zero");
+	}
+
+	return ok(a / b);
+}
+
+const result = divide(10, 2).map((n) => n * 2);
+if (result.isOk()) {
+	console.log(result.unwrap()); // 10
+} else {
+	console.error(result.unwrapErr()); // Cannot divide by zero
+}
+```
+
+### Async
+
+```ts
+import { Result, ok, err } from "@furinkapp/result";
+
+async function divide(a: number, b: number): Promise<Result<number, string>> {
+	if (b === 0) {
+		return err("Cannot divide by zero");
+	}
+
+	return ok(a / b);
+}
+
+const result = await AsyncResult.from(divide(10, 2)).map((n) => n * 2);
+
+if (result.isOk()) {
+	console.log(result.unwrap()); // 10
+} else {
+	console.error(result.unwrapErr()); // Cannot divide by zero
+}
+```

--- a/packages/result/package.json
+++ b/packages/result/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "@furinkapp/result",
+	"version": "0.1.0",
+	"description": "",
+	"main": "dist/index.js",
+	"scripts": {
+		"build": "tsc",
+		"test": "vitest"
+	},
+	"keywords": [],
+	"author": "Skye Elliot",
+	"license": "(MIT or Apache-2.0)",
+	"devDependencies": {
+		"vitest": "^0.34.1"
+	}
+}

--- a/packages/result/src/asyncResult.ts
+++ b/packages/result/src/asyncResult.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, Result } from "./result";
+import { Result } from "./result";
 
 /**
  * A fancy wrapper around `Promise` enabling the use of `Result` methods on async operations.
@@ -27,7 +27,6 @@ export interface AsyncResult<T, E> {
 	andThen<U>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E>;
 	or<F>(res: AsyncResult<T, F>): AsyncResult<T, F>;
 	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F>;
-
 	promise(): Promise<Result<T, E>>;
 }
 
@@ -74,7 +73,7 @@ class AsyncResultImpl<T, E> implements AsyncResult<T, E> {
 				if (result.isOk()) {
 					return fn(result.unwrap()).promise();
 				}
-				return Promise.resolve(result as Err<E>);
+				return Promise.resolve(result);
 			}),
 		);
 	}
@@ -89,7 +88,7 @@ class AsyncResultImpl<T, E> implements AsyncResult<T, E> {
 				if (result.isErr()) {
 					return fn(result.unwrapErr()).promise();
 				}
-				return Promise.resolve(result as Ok<T>);
+				return Promise.resolve(result);
 			}),
 		);
 	}

--- a/packages/result/src/asyncResult.ts
+++ b/packages/result/src/asyncResult.ts
@@ -11,30 +11,8 @@ export interface AsyncResult<T, E> extends Promise<Result<T, E>> {
 	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F>;
 }
 
-export interface AsyncOk<T> extends AsyncResult<T, never> {
-	unwrapOr<U>(defaultValue: U): Promise<T>;
-	unwrapOrElse<U>(fn: (err: never) => U): Promise<T>;
-	map<U>(fn: (value: T) => U): AsyncOk<U>;
-	mapErr<U>(fn: (err: never) => U): AsyncOk<U>;
-	and<U, E>(res: AsyncResult<U, E>): AsyncResult<U, E>;
-	andThen<U, E>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E>;
-	or<F>(res: AsyncResult<T, F>): AsyncOk<T>;
-	orElse<F>(fn: (err: never) => AsyncResult<T, F>): AsyncOk<T>;
-}
-
-export interface AsyncErr<E> extends AsyncResult<never, E> {
-	unwrapOr<U>(defaultValue: U): Promise<U>;
-	unwrapOrElse<U>(fn: (err: E) => U): Promise<U>;
-	map<U>(fn: (value: never) => U): AsyncErr<E>;
-	mapErr<U>(fn: (err: E) => U): AsyncErr<U>;
-	and<U>(res: AsyncResult<U, E>): AsyncErr<E>;
-	andThen<U>(fn: (value: never) => AsyncResult<U, E>): AsyncResult<U, E>;
-	or<T, F>(res: AsyncResult<T, F>): AsyncResult<T, F>;
-	orElse<T, F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F>;
-}
-
 class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult<T, E> {
-	static from<T, E>(promise: Promise<T>) {
+	static fromRaw<T, E>(promise: Promise<T>) {
 		return new AsyncResultImpl<T, E>(
 			promise.then(
 				(v) => Result.ok(v),
@@ -43,12 +21,8 @@ class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult
 		);
 	}
 
-	static ok<T>(value: T): AsyncOk<T> {
-		return new AsyncResultImpl<T, never>(Promise.resolve(Result.ok(value)));
-	}
-
-	static err<E>(err: E): AsyncErr<E> {
-		return new AsyncResultImpl<never, E>(Promise.resolve(Result.err(err)));
+	static from<T, E>(result: Promise<Result<T, E>>) {
+		return new AsyncResultImpl<T, E>(result);
 	}
 
 	private constructor(promise: Promise<Result<T, E>>) {
@@ -69,42 +43,45 @@ class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult
 		return result.unwrapOrElse(fn);
 	}
 
-	async map<U>(fn: (value: T) => U): AsyncResultImpl<U, E> {
-		const result: Result<T, E> = await this;
-		return result.map(fn);
+	map<U>(fn: (value: T) => U): AsyncResultImpl<U, E> {
+		return new AsyncResultImpl<U, E>(this.then((result) => result.map(fn)));
 	}
 
-	async mapErr<U>(fn: (err: E) => U): AsyncResult<T, U> {
-		throw new Error("Method not implemented.");
+	mapErr<U>(fn: (err: E) => U): AsyncResult<T, U> {
+		return new AsyncResultImpl<T, U>(this.then((result) => result.mapErr(fn)));
 	}
 
-	async and<U>(res: AsyncResult<U, E>): AsyncResult<U, E> {
-		throw new Error("Method not implemented.");
+	and<U>(res: AsyncResult<U, E>): AsyncResult<U, E> {
+		return new AsyncResultImpl<U, E>(
+			Promise.all([this, res])
+				.then(([a, b]) => a.and(b))
+				.catch((e) => Result.err(e)),
+		);
 	}
 
 	andThen<U>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E> {
-		throw new Error("Method not implemented.");
+		return new AsyncResultImpl<U, E>(
+			this.then((result) => result.andThen(fn)).catch((e) => Result.err(e)),
+		);
 	}
 
 	or<F>(res: AsyncResult<T, F>): AsyncResult<T, F> {
-		throw new Error("Method not implemented.");
+		return new AsyncResultImpl<T, F>(
+			Promise.all([this, res])
+				.then(([a, b]) => a.or(b))
+				.catch((e) => Result.err(e)),
+		);
 	}
 
 	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F> {
-		throw new Error("Method not implemented.");
+		return new AsyncResultImpl<T, F>(
+			this.then((result) => result.orElse(fn)).catch((e) => Result.err(e)),
+		);
 	}
 }
 
-export function asyncOk<T>(value: T) {
-	// enforce Ok<T> since unwrapOr has a different return type
-	return AsyncResult.ok(value);
-}
-export function asyncErr<E>(err: E) {
-	return AsyncResult.err(err);
-}
-
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const AsyncResult = AsyncResultImpl as unknown as {
-	ok<T>(value: T): AsyncOk<T>;
-	err<E>(err: E): AsyncErr<E>;
+export const AsyncResult = AsyncResultImpl as {
+	fromRaw<T, E>(promise: Promise<T>): AsyncResult<T, E>;
+	from<T, E>(result: Promise<Result<T, E>>): AsyncResult<T, E>;
 };

--- a/packages/result/src/asyncResult.ts
+++ b/packages/result/src/asyncResult.ts
@@ -1,8 +1,26 @@
 import { Result } from "./result";
 
+/**
+ * A fancy wrapper around `Promise` enabling the use of `Result` methods on async operations.
+ */
 export interface AsyncResult<T, E> extends Promise<Result<T, E>> {
+	/**
+	 * Unwraps the result, yielding the content of an `Ok`, or a default value.
+	 * @param defaultValue The default value to return if the result is an `Err`.
+	 */
 	unwrapOr<U>(defaultValue: U): Promise<T | U>;
+	/**
+	 * Unwraps the result, yielding the content of an `Ok`, or computes a default.
+	 * @param fn A function that computes a default value. This function should not throw, otherwise
+	 * you will escape the Result-handling monad.
+	 */
 	unwrapOrElse<U>(fn: (err: E) => U): Promise<T | U>;
+	/**
+	 * Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a contained `Ok` value,
+	 * leaving an `Err` value untouched.
+	 * @param fn The function to apply to the contained `Ok` value. This function should not throw,
+	 * otherwise you will escape the Result-handling monad.
+	 */
 	map<U>(fn: (value: T) => U): AsyncResult<U, E>;
 	mapErr<U>(fn: (err: E) => U): AsyncResult<T, U>;
 	and<U>(res: AsyncResult<U, E>): AsyncResult<U, E>;
@@ -33,14 +51,12 @@ class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult
 		);
 	}
 
-	async unwrapOr<U>(defaultValue: U): Promise<T | U> {
-		const result: Result<T, E> = await this;
-		return result.unwrapOr(defaultValue);
+	unwrapOr<U>(defaultValue: U): Promise<T | U> {
+		return this.then((result) => result.unwrapOr(defaultValue));
 	}
 
-	async unwrapOrElse<U>(fn: (err: E) => U): Promise<T | U> {
-		const result: Result<T, E> = await this;
-		return result.unwrapOrElse(fn);
+	unwrapOrElse<U>(fn: (err: E) => U): Promise<T | U> {
+		return this.then((result) => result.unwrapOrElse(fn));
 	}
 
 	map<U>(fn: (value: T) => U): AsyncResultImpl<U, E> {
@@ -52,25 +68,15 @@ class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult
 	}
 
 	and<U>(res: AsyncResult<U, E>): AsyncResult<U, E> {
-		return new AsyncResultImpl<U, E>(
-			Promise.all([this, res])
-				.then(([a, b]) => a.and(b))
-				.catch((e) => Result.err(e)),
-		);
+		return new AsyncResultImpl<U, E>(Promise.all([this, res]).then(([a, b]) => a.and(b)));
 	}
 
 	andThen<U>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E> {
-		return new AsyncResultImpl<U, E>(
-			this.then((result) => result.andThen(fn)).catch((e) => Result.err(e)),
-		);
+		return new AsyncResultImpl<U, E>(this.then((result) => result.andThen(fn)));
 	}
 
 	or<F>(res: AsyncResult<T, F>): AsyncResult<T, F> {
-		return new AsyncResultImpl<T, F>(
-			Promise.all([this, res])
-				.then(([a, b]) => a.or(b))
-				.catch((e) => Result.err(e)),
-		);
+		return new AsyncResultImpl<T, F>(Promise.all([this, res]).then(([a, b]) => a.or(b)));
 	}
 
 	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F> {

--- a/packages/result/src/asyncResult.ts
+++ b/packages/result/src/asyncResult.ts
@@ -30,7 +30,7 @@ export interface AsyncResult<T, E> extends Promise<Result<T, E>> {
 }
 
 class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult<T, E> {
-	static fromRaw<T, E>(promise: Promise<T>) {
+	static fromRaw<T, E>(promise: Promise<T>): AsyncResult<T, E> {
 		return new AsyncResultImpl<T, E>(
 			promise.then(
 				(v) => Result.ok(v),
@@ -60,27 +60,28 @@ class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult
 	}
 
 	map<U>(fn: (value: T) => U): AsyncResultImpl<U, E> {
-		return new AsyncResultImpl<U, E>(this.then((result) => result.map(fn)));
+		console.log(this);
+		return new AsyncResultImpl(this.then((result) => result.map(fn)));
 	}
 
 	mapErr<U>(fn: (err: E) => U): AsyncResult<T, U> {
-		return new AsyncResultImpl<T, U>(this.then((result) => result.mapErr(fn)));
+		return new AsyncResultImpl(this.then((result) => result.mapErr(fn)));
 	}
 
 	and<U>(res: AsyncResult<U, E>): AsyncResult<U, E> {
-		return new AsyncResultImpl<U, E>(Promise.all([this, res]).then(([a, b]) => a.and(b)));
+		return new AsyncResultImpl(Promise.all([this, res]).then(([a, b]) => a.and(b)));
 	}
 
 	andThen<U>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E> {
-		return new AsyncResultImpl<U, E>(this.then((result) => result.andThen(fn)));
+		return new AsyncResultImpl(this.then((result) => result.andThen(fn)));
 	}
 
 	or<F>(res: AsyncResult<T, F>): AsyncResult<T, F> {
-		return new AsyncResultImpl<T, F>(Promise.all([this, res]).then(([a, b]) => a.or(b)));
+		return new AsyncResultImpl(Promise.all([this, res]).then(([a, b]) => a.or(b)));
 	}
 
 	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F> {
-		return new AsyncResultImpl<T, F>(
+		return new AsyncResultImpl(
 			this.then((result) => result.orElse(fn)).catch((e) => Result.err(e)),
 		);
 	}

--- a/packages/result/src/asyncResult.ts
+++ b/packages/result/src/asyncResult.ts
@@ -1,0 +1,110 @@
+import { Result } from "./result";
+
+export interface AsyncResult<T, E> extends Promise<Result<T, E>> {
+	unwrapOr<U>(defaultValue: U): Promise<T | U>;
+	unwrapOrElse<U>(fn: (err: E) => U): Promise<T | U>;
+	map<U>(fn: (value: T) => U): AsyncResult<U, E>;
+	mapErr<U>(fn: (err: E) => U): AsyncResult<T, U>;
+	and<U>(res: AsyncResult<U, E>): AsyncResult<U, E>;
+	andThen<U>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E>;
+	or<F>(res: AsyncResult<T, F>): AsyncResult<T, F>;
+	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F>;
+}
+
+export interface AsyncOk<T> extends AsyncResult<T, never> {
+	unwrapOr<U>(defaultValue: U): Promise<T>;
+	unwrapOrElse<U>(fn: (err: never) => U): Promise<T>;
+	map<U>(fn: (value: T) => U): AsyncOk<U>;
+	mapErr<U>(fn: (err: never) => U): AsyncOk<U>;
+	and<U, E>(res: AsyncResult<U, E>): AsyncResult<U, E>;
+	andThen<U, E>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E>;
+	or<F>(res: AsyncResult<T, F>): AsyncOk<T>;
+	orElse<F>(fn: (err: never) => AsyncResult<T, F>): AsyncOk<T>;
+}
+
+export interface AsyncErr<E> extends AsyncResult<never, E> {
+	unwrapOr<U>(defaultValue: U): Promise<U>;
+	unwrapOrElse<U>(fn: (err: E) => U): Promise<U>;
+	map<U>(fn: (value: never) => U): AsyncErr<E>;
+	mapErr<U>(fn: (err: E) => U): AsyncErr<U>;
+	and<U>(res: AsyncResult<U, E>): AsyncErr<E>;
+	andThen<U>(fn: (value: never) => AsyncResult<U, E>): AsyncResult<U, E>;
+	or<T, F>(res: AsyncResult<T, F>): AsyncResult<T, F>;
+	orElse<T, F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F>;
+}
+
+class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult<T, E> {
+	static from<T, E>(promise: Promise<T>) {
+		return new AsyncResultImpl<T, E>(
+			promise.then(
+				(v) => Result.ok(v),
+				(e: E) => Result.err(e),
+			),
+		);
+	}
+
+	static ok<T>(value: T): AsyncOk<T> {
+		return new AsyncResultImpl<T, never>(Promise.resolve(Result.ok(value)));
+	}
+
+	static err<E>(err: E): AsyncErr<E> {
+		return new AsyncResultImpl<never, E>(Promise.resolve(Result.err(err)));
+	}
+
+	private constructor(promise: Promise<Result<T, E>>) {
+		super((resolve) =>
+			promise.then(resolve, () => {
+				throw new Error("Unreachable - file a bug report if you see this!");
+			}),
+		);
+	}
+
+	async unwrapOr<U>(defaultValue: U): Promise<T | U> {
+		const result: Result<T, E> = await this;
+		return result.unwrapOr(defaultValue);
+	}
+
+	async unwrapOrElse<U>(fn: (err: E) => U): Promise<T | U> {
+		const result: Result<T, E> = await this;
+		return result.unwrapOrElse(fn);
+	}
+
+	async map<U>(fn: (value: T) => U): AsyncResultImpl<U, E> {
+		const result: Result<T, E> = await this;
+		return result.map(fn);
+	}
+
+	async mapErr<U>(fn: (err: E) => U): AsyncResult<T, U> {
+		throw new Error("Method not implemented.");
+	}
+
+	async and<U>(res: AsyncResult<U, E>): AsyncResult<U, E> {
+		throw new Error("Method not implemented.");
+	}
+
+	andThen<U>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E> {
+		throw new Error("Method not implemented.");
+	}
+
+	or<F>(res: AsyncResult<T, F>): AsyncResult<T, F> {
+		throw new Error("Method not implemented.");
+	}
+
+	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F> {
+		throw new Error("Method not implemented.");
+	}
+}
+
+export function asyncOk<T>(value: T) {
+	// enforce Ok<T> since unwrapOr has a different return type
+	return AsyncResult.ok(value);
+}
+export function asyncErr<E>(err: E) {
+	return AsyncResult.err(err);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AsyncResult = AsyncResultImpl as unknown as {
+	ok<T>(value: T): AsyncOk<T>;
+	err<E>(err: E): AsyncErr<E>;
+};

--- a/packages/result/src/asyncResult.ts
+++ b/packages/result/src/asyncResult.ts
@@ -1,9 +1,9 @@
-import { Result } from "./result";
+import { Err, Ok, Result } from "./result";
 
 /**
  * A fancy wrapper around `Promise` enabling the use of `Result` methods on async operations.
  */
-export interface AsyncResult<T, E> extends Promise<Result<T, E>> {
+export interface AsyncResult<T, E> {
 	/**
 	 * Unwraps the result, yielding the content of an `Ok`, or a default value.
 	 * @param defaultValue The default value to return if the result is an `Err`.
@@ -27,9 +27,11 @@ export interface AsyncResult<T, E> extends Promise<Result<T, E>> {
 	andThen<U>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E>;
 	or<F>(res: AsyncResult<T, F>): AsyncResult<T, F>;
 	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F>;
+
+	promise(): Promise<Result<T, E>>;
 }
 
-class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult<T, E> {
+class AsyncResultImpl<T, E> implements AsyncResult<T, E> {
 	static fromRaw<T, E>(promise: Promise<T>): AsyncResult<T, E> {
 		return new AsyncResultImpl<T, E>(
 			promise.then(
@@ -39,56 +41,79 @@ class AsyncResultImpl<T, E> extends Promise<Result<T, E>> implements AsyncResult
 		);
 	}
 
-	static from<T, E>(result: Promise<Result<T, E>>) {
+	static fromInfallible<T, E>(result: Promise<Result<T, E>>) {
 		return new AsyncResultImpl<T, E>(result);
 	}
 
-	private constructor(promise: Promise<Result<T, E>>) {
-		super((resolve) =>
-			promise.then(resolve, () => {
-				throw new Error("Unreachable - file a bug report if you see this!");
-			}),
-		);
-	}
+	private constructor(private readonly inner: Promise<Result<T, E>>) {}
 
 	unwrapOr<U>(defaultValue: U): Promise<T | U> {
-		return this.then((result) => result.unwrapOr(defaultValue));
+		return this.inner.then((result) => result.unwrapOr(defaultValue));
 	}
 
 	unwrapOrElse<U>(fn: (err: E) => U): Promise<T | U> {
-		return this.then((result) => result.unwrapOrElse(fn));
+		return this.inner.then((result) => result.unwrapOrElse(fn));
 	}
 
 	map<U>(fn: (value: T) => U): AsyncResultImpl<U, E> {
 		console.log(this);
-		return new AsyncResultImpl(this.then((result) => result.map(fn)));
+		return new AsyncResultImpl(this.inner.then((result) => result.map(fn)));
 	}
 
 	mapErr<U>(fn: (err: E) => U): AsyncResult<T, U> {
-		return new AsyncResultImpl(this.then((result) => result.mapErr(fn)));
+		return new AsyncResultImpl(this.inner.then((result) => result.mapErr(fn)));
 	}
 
 	and<U>(res: AsyncResult<U, E>): AsyncResult<U, E> {
-		return new AsyncResultImpl(Promise.all([this, res]).then(([a, b]) => a.and(b)));
+		return new AsyncResultImpl(Promise.all([this.inner, res.promise()]).then(([a, b]) => a.and(b)));
 	}
 
 	andThen<U>(fn: (value: T) => AsyncResult<U, E>): AsyncResult<U, E> {
-		return new AsyncResultImpl(this.then((result) => result.andThen(fn)));
+		return new AsyncResultImpl(
+			this.inner.then(async (result) => {
+				if (result.isOk()) {
+					return fn(result.unwrap()).promise();
+				}
+				return Promise.resolve(result as Err<E>);
+			}),
+		);
 	}
 
 	or<F>(res: AsyncResult<T, F>): AsyncResult<T, F> {
-		return new AsyncResultImpl(Promise.all([this, res]).then(([a, b]) => a.or(b)));
+		return new AsyncResultImpl(Promise.all([this.inner, res.promise()]).then(([a, b]) => a.or(b)));
 	}
 
 	orElse<F>(fn: (err: E) => AsyncResult<T, F>): AsyncResult<T, F> {
 		return new AsyncResultImpl(
-			this.then((result) => result.orElse(fn)).catch((e) => Result.err(e)),
+			this.inner.then((result) => {
+				if (result.isErr()) {
+					return fn(result.unwrapErr()).promise();
+				}
+				return Promise.resolve(result as Ok<T>);
+			}),
 		);
+	}
+
+	/**
+	 * Unwraps the inner promise. This promise is guaranteed to never reject.
+	 * @returns
+	 */
+	promise() {
+		return this.inner;
 	}
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const AsyncResult = AsyncResultImpl as {
+	/**
+	 * Creates a new `AsyncResult` from a `Promise`. This method adds a layer of indirection preventing
+	 * rejection of the promise from escaping the `AsyncResult` monad.
+	 */
 	fromRaw<T, E>(promise: Promise<T>): AsyncResult<T, E>;
-	from<T, E>(result: Promise<Result<T, E>>): AsyncResult<T, E>;
+	/**
+	 * Creates a new `AsyncResult` from a `Promise<Result<T, E>>`. Unlike `fromRaw`, this method assumes
+	 * that the promise will never be rejected.
+	 * @param result
+	 */
+	fromInfallible<T, E>(result: Promise<Result<T, E>>): AsyncResult<T, E>;
 };

--- a/packages/result/src/index.ts
+++ b/packages/result/src/index.ts
@@ -1,2 +1,2 @@
 export { Result, err, ok } from "./result";
-export { AsyncResult, asyncErr, asyncOk } from "./asyncResult";
+export { AsyncResult } from "./asyncResult";

--- a/packages/result/src/index.ts
+++ b/packages/result/src/index.ts
@@ -1,0 +1,2 @@
+export { Result, err, ok } from "./result";
+export { AsyncResult, asyncErr, asyncOk } from "./asyncResult";

--- a/packages/result/src/result.ts
+++ b/packages/result/src/result.ts
@@ -1,11 +1,48 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 
+/**
+ * A type that represents either success (`Ok`) or failure (`Err`).
+ */
 export interface Result<T, E> {
+	/**
+	 * Unwraps the result, or uses a default value if the result is an error.
+	 * @param defaultValue
+	 */
 	unwrapOr<U>(defaultValue: U): T | U;
+	/**
+	 * Unwraps the result, or computes a default value from the error.
+	 * @param fn The function to call if the result is an error. This function should not throw as
+	 * this will escape the Result-handling process!
+	 */
 	unwrapOrElse<U>(fn: (err: E) => U): T | U;
+	/**
+	 * Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a contained Ok value, leaving
+	 * an Err value untouched.
+	 * @param fn The function to call if the result is Ok. This function should not throw as this
+	 * will escape the Result-handling process!
+	 */
 	map<U>(fn: (value: T) => U): Result<U, E>;
+	/**
+	 * Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a contained Err value, leaving
+	 * an Ok value untouched.
+	 * @param fn The function to call if the result is Err. This function should not throw as this
+	 * will escape the Result-handling process!
+	 */
 	mapErr<U>(fn: (err: E) => U): Result<T, U>;
+	/**
+	 * Returns res if the result is Ok, otherwise returns the Err value of self.
+	 * @param res The result to return if this result is Ok.
+	 * @returns res if the result is Ok, otherwise returns the Err value of self.
+	 */
 	and<U>(res: Result<U, E>): Result<U, E>;
+	/**
+	 * Returns the result of applying fn to the contained value if this result is Ok, otherwise
+	 * returns the Err value of self.
+	 * @param fn The function to call if the result is Ok. This function should not throw as this
+	 * will escape the Result-handling process!
+	 * @returns the result of applying fn to the contained value if this result is Ok, otherwise
+	 * returns the Err value of self.
+	 */
 	andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E>;
 	or<F>(res: Result<T, F>): Result<T, F>;
 	orElse<F>(fn: (err: E) => Result<T, F>): Result<T, F>;
@@ -139,16 +176,33 @@ class ResultImpl<T, E> implements Result<T, E> {
 	}
 }
 
+/**
+ * Creates a new `Ok` result.
+ * @param value The value to wrap.
+ */
 export function ok<T>(value: T) {
 	// enforce Ok<T> since unwrapOr has a different return type
 	return ResultImpl.ok(value);
 }
+
+/**
+ * Creates a new `Err` result.
+ * @param err The error to wrap.
+ */
 export function err<E>(err: E): Err<E> {
 	return ResultImpl.err(err);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const Result = ResultImpl as unknown as {
+	/**
+	 * Creates a new `Ok` result.
+	 * @param value The value to wrap.
+	 */
 	ok<T>(value: T): Ok<T>;
+	/**
+	 * Creates a new `Err` result.
+	 * @param err The error to wrap.
+	 */
 	err<E>(err: E): Err<E>;
 };

--- a/packages/result/src/result.ts
+++ b/packages/result/src/result.ts
@@ -1,86 +1,31 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 
-/**
- * A type that represents either success (`Ok`) or failure (`Err`).
- */
-export interface Result<T, E> {
-	/**
-	 * Unwraps the result, or uses a default value if the result is an error.
-	 * @param defaultValue
-	 */
+export interface BaseResult<T, E> {
 	unwrapOr<U>(defaultValue: U): T | U;
-	/**
-	 * Unwraps the result, or computes a default value from the error.
-	 * @param fn The function to call if the result is an error. This function should not throw as
-	 * this will escape the Result-handling process!
-	 */
 	unwrapOrElse<U>(fn: (err: E) => U): T | U;
-	/**
-	 * Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a contained Ok value, leaving
-	 * an Err value untouched.
-	 * @param fn The function to call if the result is Ok. This function should not throw as this
-	 * will escape the Result-handling process!
-	 */
 	map<U>(fn: (value: T) => U): Result<U, E>;
-	/**
-	 * Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a contained Err value, leaving
-	 * an Ok value untouched.
-	 * @param fn The function to call if the result is Err. This function should not throw as this
-	 * will escape the Result-handling process!
-	 */
 	mapErr<U>(fn: (err: E) => U): Result<T, U>;
-	/**
-	 * Returns res if the result is Ok, otherwise returns the Err value of self.
-	 * @param res The result to return if this result is Ok.
-	 * @returns res if the result is Ok, otherwise returns the Err value of self.
-	 */
 	and<U>(res: Result<U, E>): Result<U, E>;
-	/**
-	 * Returns the result of applying fn to the contained value if this result is Ok, otherwise
-	 * returns the Err value of self.
-	 * @param fn The function to call if the result is Ok. This function should not throw as this
-	 * will escape the Result-handling process!
-	 * @returns the result of applying fn to the contained value if this result is Ok, otherwise
-	 * returns the Err value of self.
-	 */
 	andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E>;
 	or<F>(res: Result<T, F>): Result<T, F>;
 	orElse<F>(fn: (err: E) => Result<T, F>): Result<T, F>;
 	isOk(): this is Ok<T>;
 	isErr(): this is Err<E>;
+	assertOk(): asserts this is Ok<T>;
+	assertErr(): asserts this is Err<T>;
 }
 
-export interface Ok<T> extends Result<T, never> {
+export interface Ok<T> extends BaseResult<T, never> {
 	unwrap(): T;
-	unwrapErr(): never;
-
-	// overrides
-	unwrapOr(defaultValue: unknown): T;
-	unwrapOrElse(fn: (err: never) => unknown): T;
-	map<U>(fn: (value: T) => U): Ok<U>;
-	mapErr<U>(fn: (err: never) => U): this;
-	and<U, E>(res: Result<U, E>): Result<U, E>;
-	andThen<U, E>(fn: (value: T) => Result<U, E>): Result<U, E>;
-	or<F>(res: Result<T, F>): this;
-	orElse<F>(fn: (err: never) => Result<T, F>): this;
 }
 
-export interface Err<E> extends Result<never, E> {
-	unwrap(): never;
+export interface Err<E> extends BaseResult<never, E> {
 	unwrapErr(): E;
-
-	// overrides
-	unwrapOr<U>(defaultValue: U): U;
-	unwrapOrElse<U>(fn: (err: E) => U): U;
-	map<U>(fn: (value: never) => U): this;
-	mapErr<U>(fn: (err: E) => U): Err<U>;
-	and<U>(res: Result<U, E>): this;
-	andThen<U>(fn: (value: never) => Result<U, E>): this;
-	or<T, F>(res: Result<T, F>): Result<T, F>;
-	orElse<T, F>(fn: (err: E) => Result<T, F>): Result<T, F>;
 }
 
-class ResultImpl<T, E> implements Result<T, E> {
+export type Result<T, E> = Ok<T> | Err<E>;
+
+class ResultImpl<T, E> implements BaseResult<T, E> {
 	static ok<T>(value: T): Ok<T> {
 		return new ResultImpl(true, value, undefined as never) as unknown as Ok<T>;
 	}
@@ -96,6 +41,18 @@ class ResultImpl<T, E> implements Result<T, E> {
 		// eslint-disable-next-line @typescript-eslint/no-shadow
 		private readonly err: E,
 	) {}
+
+	assertOk(): asserts this is Ok<T> {
+		if (!this.ok) {
+			throw new Error("assertOk called on 'Err' variant");
+		}
+	}
+
+	assertErr(): asserts this is Err<T> {
+		if (this.ok) {
+			throw new Error("assertErr called on 'Ok' variant");
+		}
+	}
 
 	unwrap(): T {
 		if (this.isOk()) {

--- a/packages/result/src/result.ts
+++ b/packages/result/src/result.ts
@@ -1,0 +1,154 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+
+export interface Result<T, E> {
+	unwrapOr<U>(defaultValue: U): T | U;
+	unwrapOrElse<U>(fn: (err: E) => U): T | U;
+	map<U>(fn: (value: T) => U): Result<U, E>;
+	mapErr<U>(fn: (err: E) => U): Result<T, U>;
+	and<U>(res: Result<U, E>): Result<U, E>;
+	andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E>;
+	or<F>(res: Result<T, F>): Result<T, F>;
+	orElse<F>(fn: (err: E) => Result<T, F>): Result<T, F>;
+	isOk(): this is Ok<T>;
+	isErr(): this is Err<E>;
+}
+
+export interface Ok<T> extends Result<T, never> {
+	unwrap(): T;
+	unwrapErr(): never;
+
+	// overrides
+	unwrapOr(defaultValue: unknown): T;
+	unwrapOrElse(fn: (err: never) => unknown): T;
+	map<U>(fn: (value: T) => U): Ok<U>;
+	mapErr<U>(fn: (err: never) => U): this;
+	and<U, E>(res: Result<U, E>): Result<U, E>;
+	andThen<U, E>(fn: (value: T) => Result<U, E>): Result<U, E>;
+	or<F>(res: Result<T, F>): this;
+	orElse<F>(fn: (err: never) => Result<T, F>): this;
+}
+
+export interface Err<E> extends Result<never, E> {
+	unwrap(): never;
+	unwrapErr(): E;
+
+	// overrides
+	unwrapOr<U>(defaultValue: U): U;
+	unwrapOrElse<U>(fn: (err: E) => U): U;
+	map<U>(fn: (value: never) => U): this;
+	mapErr<U>(fn: (err: E) => U): Err<U>;
+	and<U>(res: Result<U, E>): this;
+	andThen<U>(fn: (value: never) => Result<U, E>): this;
+	or<T, F>(res: Result<T, F>): Result<T, F>;
+	orElse<T, F>(fn: (err: E) => Result<T, F>): Result<T, F>;
+}
+
+class ResultImpl<T, E> implements Result<T, E> {
+	static ok<T>(value: T): Ok<T> {
+		return new ResultImpl(true, value, undefined as never) as unknown as Ok<T>;
+	}
+
+	static err<E>(err: E): Err<E> {
+		return new ResultImpl(false, undefined as never, err) as unknown as Err<E>;
+	}
+
+	constructor(
+		// eslint-disable-next-line @typescript-eslint/no-shadow
+		private readonly ok: boolean,
+		private readonly value: T,
+		// eslint-disable-next-line @typescript-eslint/no-shadow
+		private readonly err: E,
+	) {}
+
+	unwrap(): T {
+		if (this.isOk()) {
+			return this.value;
+		}
+		throw new Error("Called unwrap on an Err value");
+	}
+
+	unwrapErr(): E {
+		if (this.isErr()) {
+			return this.err;
+		}
+		throw new Error("Called unwrapErr on an Ok value");
+	}
+
+	unwrapOr<U>(defaultValue: U): T | U {
+		if (this.isOk()) {
+			return this.value;
+		}
+		return defaultValue;
+	}
+
+	unwrapOrElse<U>(fn: (err: E) => U): T | U {
+		if (this.ok) {
+			return this.value;
+		}
+		return fn(this.err);
+	}
+
+	map<U>(fn: (value: T) => U): Result<U, E> {
+		if (this.isOk()) {
+			return Result.ok(fn(this.value));
+		}
+		return this as unknown as Err<E>;
+	}
+
+	mapErr<U>(fn: (err: E) => U): Result<T, U> {
+		if (this.isErr()) {
+			return Result.err(fn(this.err));
+		}
+		return this as unknown as Ok<T>;
+	}
+
+	and<U>(res: Result<U, E>): Result<U, E> {
+		if (this.ok) {
+			return res;
+		}
+		return this as unknown as Err<E>;
+	}
+
+	andThen<U>(fn: (value: T) => Result<U, E>): Result<U, E> {
+		if (this.isOk()) {
+			return fn(this.value);
+		}
+		return this as unknown as Err<E>;
+	}
+
+	or<F>(res: Result<T, F>): Result<T, F> {
+		if (this.isErr()) {
+			return res;
+		}
+		return this as unknown as Ok<T>;
+	}
+
+	orElse<F>(fn: (err: E) => Result<T, F>): Result<T, F> {
+		if (this.isErr()) {
+			return fn(this.err);
+		}
+		return this as unknown as Ok<T>;
+	}
+
+	isOk(): this is Ok<T> {
+		return this.ok;
+	}
+
+	isErr(): this is Err<E> {
+		return !this.ok;
+	}
+}
+
+export function ok<T>(value: T) {
+	// enforce Ok<T> since unwrapOr has a different return type
+	return ResultImpl.ok(value);
+}
+export function err<E>(err: E): Err<E> {
+	return ResultImpl.err(err);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const Result = ResultImpl as unknown as {
+	ok<T>(value: T): Ok<T>;
+	err<E>(err: E): Err<E>;
+};

--- a/packages/result/src/tuple.ts
+++ b/packages/result/src/tuple.ts
@@ -1,0 +1,2 @@
+/* eslint-disable @typescript-eslint/no-type-alias */
+export type Append<T extends unknown[], X> = [...T, X];

--- a/packages/result/src/tuple.ts
+++ b/packages/result/src/tuple.ts
@@ -1,2 +1,0 @@
-/* eslint-disable @typescript-eslint/no-type-alias */
-export type Append<T extends unknown[], X> = [...T, X];

--- a/packages/result/tests/asyncResult.test.ts
+++ b/packages/result/tests/asyncResult.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { asyncOk } from "../src";
+
+describe("AsyncResult", () => {
+	it("should work", async () => {
+		const result = await asyncOk(3)
+			.and(asyncOk(4))
+			.map((v) => v + 3);
+
+		expect(result).toBe(6);
+	});
+});

--- a/packages/result/tests/asyncResult.test.ts
+++ b/packages/result/tests/asyncResult.test.ts
@@ -1,13 +1,29 @@
-import { describe, expect } from "vitest";
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 
-import { AsyncResult } from "../src";
+import { describe, expect, it } from "vitest";
+
+import { AsyncResult } from "../src/AsyncResult";
 
 describe("AsyncResult", () => {
-	describe("AsyncResult.fromRaw", async () => {
-		const myFunction = async () => 42;
-		const result = await AsyncResult.fromRaw(myFunction()).map((value) => value * 2);
-		expect(result.isOk());
-		//@ts-expect-error
-		expect(result.unwrap()).toBe(84);
+	describe("AsyncResult.fromRaw", () => {
+		it("should process resolving promises", async () => {
+			const myFunction = async () => 42;
+			const result = await AsyncResult.fromRaw(myFunction())
+				.map((v) => v + 27)
+				.promise();
+			expect(result.isOk()).toBe(true);
+			// @ts-expect-error - we know it's ok
+			expect(result.unwrap()).toBe(69);
+		});
+		it("should process rejecting promises", async () => {
+			const myFunction = async () => {
+				throw new Error("kaylen dog");
+			};
+			const result = await AsyncResult.fromRaw(myFunction()).promise();
+			expect(result.isErr()).toBe(true);
+			// @ts-expect-error - we know it's err
+			expect(result.unwrapErr()).toStrictEqual(new Error("kaylen dog"));
+		});
 	});
 });

--- a/packages/result/tests/asyncResult.test.ts
+++ b/packages/result/tests/asyncResult.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect } from "vitest";
 
-import { asyncOk } from "../src";
+import { AsyncResult } from "../src";
 
 describe("AsyncResult", () => {
-	it("should work", async () => {
-		const result = await asyncOk(3)
-			.and(asyncOk(4))
-			.map((v) => v + 3);
-
-		expect(result).toBe(6);
+	describe("AsyncResult.fromRaw", async () => {
+		const myFunction = async () => 42;
+		const result = await AsyncResult.fromRaw(myFunction()).map((value) => value * 2);
+		expect(result.isOk());
+		//@ts-expect-error
+		expect(result.unwrap()).toBe(84);
 	});
 });

--- a/packages/result/tests/result.test.ts
+++ b/packages/result/tests/result.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { Result } from "../src/result";
+
+describe("Result", () => {
+	describe("Result.ok", () => {
+		it("should return an 'Ok' result variant", () => {
+			const result = Result.ok(1);
+			expect(result.isOk());
+		});
+	});
+	describe("Result.err", () => {
+		it("should return an 'Err' result variant", () => {
+			const result = Result.err(1);
+			expect(result.isErr());
+		});
+	});
+	describe("Result.map", () => {
+		it("should produce the mapped value when invoked on an 'Ok' variant", () => {
+			const result = Result.ok(1);
+			const mapped = result.map((value) => value + 1);
+			expect(mapped.isOk());
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			expect(mapped.unwrap()).toBe(2);
+		});
+		it("should produce the original value when invoked on an 'Err' variant", () => {
+			const result = Result.err(1);
+			const mapped = result.map((value: number) => value + 1);
+			expect(mapped.isErr());
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			expect(mapped.unwrapErr()).toBe(1);
+		});
+	});
+	describe("Result.mapErr", () => {
+		it("should produce the mapped value when invoked on an 'Err' variant", () => {
+			const result = Result.err(1);
+			const mapped = result.mapErr((value) => value + 1);
+			expect(mapped.isErr());
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			expect(mapped.unwrapErr()).toBe(2);
+		});
+		it("should produce the original value when invoked on an 'Ok' variant", () => {
+			const result = Result.ok(1);
+			const mapped = result.mapErr((value: number) => value + 1);
+			expect(mapped.isOk());
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			expect(mapped.unwrap()).toBe(1);
+		});
+	});
+	describe("Result.and", () => {
+		it("should return an 'Ok' the mapped value when invoked on an 'Ok' variant", () => {
+			const result = Result.ok(1);
+			const mapped = result.and(Result.ok(2));
+			expect(mapped.isOk());
+			// @ts-expect-error Test does not check for 'Err' variant
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			expect(mapped.unwrap()).toBe(2);
+		});
+		it("should produce the original value when invoked on an 'Err' variant", () => {
+			const result = Result.err(1);
+			const mapped = result.and(Result.ok(2));
+			expect(mapped.isErr());
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			expect(mapped.unwrapErr()).toBe(1);
+		});
+		it("should produce the original value when invoked on an 'Ok' variant", () => {
+			const result = Result.ok(1);
+			const mapped = result.and(Result.err(2));
+		});
+	});
+	describe("Result.andThen", () => {
+		it("should produce the mapped value when invoked on an 'Ok' variant", () => {
+			const result = Result.ok(1);
+			let wasInvoked = false;
+			const mapped = result.andThen((value) => {
+				wasInvoked = true;
+				return Result.ok(value + 1);
+			});
+			expect(mapped.isOk());
+			expect(wasInvoked).toBe(true);
+			// @ts-expect-error Test does not check for 'Err' variant
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			expect(mapped.unwrap()).toBe(2);
+		});
+		it("should produce the original value when invoked on an 'Err' variant", () => {
+			const result = Result.err(1);
+			let wasInvoked = false;
+			const mapped = result.andThen((value: number) => {
+				wasInvoked = true;
+				return Result.ok(value + 1);
+			});
+			expect(mapped.isErr());
+			expect(wasInvoked).toBe(false);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			expect(mapped.unwrapErr()).toBe(1);
+		});
+	});
+});

--- a/packages/result/tests/result.test.ts
+++ b/packages/result/tests/result.test.ts
@@ -20,14 +20,12 @@ describe("Result", () => {
 			const result = Result.ok(1);
 			const mapped = result.map((value) => value + 1);
 			expect(mapped.isOk());
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			expect(mapped.unwrap()).toBe(2);
 		});
 		it("should produce the original value when invoked on an 'Err' variant", () => {
 			const result = Result.err(1);
 			const mapped = result.map((value: number) => value + 1);
 			expect(mapped.isErr());
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			expect(mapped.unwrapErr()).toBe(1);
 		});
 	});
@@ -35,15 +33,14 @@ describe("Result", () => {
 		it("should produce the mapped value when invoked on an 'Err' variant", () => {
 			const result = Result.err(1);
 			const mapped = result.mapErr((value) => value + 1);
-			expect(mapped.isErr());
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			mapped.assertErr();
 			expect(mapped.unwrapErr()).toBe(2);
 		});
 		it("should produce the original value when invoked on an 'Ok' variant", () => {
 			const result = Result.ok(1);
 			const mapped = result.mapErr((value: number) => value + 1);
-			expect(mapped.isOk());
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+
+			mapped.assertOk();
 			expect(mapped.unwrap()).toBe(1);
 		});
 	});
@@ -92,7 +89,7 @@ describe("Result", () => {
 			});
 			expect(mapped.isErr());
 			expect(wasInvoked).toBe(false);
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+			mapped.assertErr();
 			expect(mapped.unwrapErr()).toBe(1);
 		});
 	});

--- a/packages/result/tests/result.test.ts
+++ b/packages/result/tests/result.test.ts
@@ -66,6 +66,7 @@ describe("Result", () => {
 		it("should produce the original value when invoked on an 'Ok' variant", () => {
 			const result = Result.ok(1);
 			const mapped = result.and(Result.err(2));
+			expect(mapped.isErr()).toBe(true);
 		});
 	});
 	describe("Result.andThen", () => {

--- a/packages/result/tsconfig.json
+++ b/packages/result/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "CommonJS",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"strict": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/packages/result/tsconfig.test.json
+++ b/packages/result/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
+}

--- a/packages/result/vitest.config.ts
+++ b/packages/result/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({});


### PR DESCRIPTION
- Implements a `Result<T, E>` type
- Implements a `AsyncResult<T, E>` type 

## Usage

```ts
const myFunction = () => {
    if (Math.random() > 0.5) {
        return Result.ok("Yay!");
    }
    return Result.err("Oh no!");
}

const result = myFunction()
    .map((v) => v + "Hello, world!")
    .mapErr((v) => v + "Goodbye, world!");

// enforces developers check `Result.isOk` before unwrapping
if (result.isOk()) {
    console.log(result.unwrap());
} else {
    console.log(result.unwrapErr());
}


```